### PR TITLE
Add support of startWorldURL command

### DIFF
--- a/commands.txt
+++ b/commands.txt
@@ -32,6 +32,9 @@ status
 friendRequests
 	Lists all incoming friend requests
 	Usage: friendrequests
+startWorldURL
+	Start a new world from URL
+	Usage: startworldurl <record URL>
 sessionUrl
 	Prints the URL of the current session
 	Usage: sessionurl 
@@ -123,9 +126,6 @@ saveConfig
 acceptFriendRequest
 	Accepts a friend request
 	Usage: acceptfriendrequest <friend name>
-startWorldURL
-	Start a new world from URL
-	Usage: startworldurl <record URL>
 startWorldTemplate
 	Start a new world from template
 	Usage: startworldtemplate <template name>

--- a/neosvr_headless_api/__init__.py
+++ b/neosvr_headless_api/__init__.py
@@ -438,14 +438,26 @@ class HeadlessClient:
             if ln in errors:
                 raise NeosError(ln)
 
-    # TODO: Implement `startWorldURL` here
-    def start_world_url(self, *args, **kwargs):
+    def start_world_url(self, world_url: str):
         """
-        Not yet implemented
+        Start a world based on a neos record url
 
-        Raises `NotImplementedError`
+        Return nothing on success
+
+        Raise `NeosError` if the neos record format is invalid
+        Raise `NeosError` if the world cannot be started
+        Raise `UnhandledError` for any unknown errors
         """
-        raise NotImplementedError("Not yet implemented")
+        if not world_url.startswith('neosrec://'):
+            raise NeosError('Invalid neos record format')
+        cmd = self.send_command('startWorldURL  "%s"' % (world_url))
+        if "World running..." in cmd:
+            return
+        elif len(cmd) == 1 and "Resolving SessionID: " in cmd:
+            return NeosError(
+                "Can't resolve world url. Not enough permissions?"
+            )
+        raise UnhandledError("\n".join(cmd))
 
     # TODO: Implement `startWorldTemplate` here
     def start_world_template(self, *args, **kwargs):


### PR DESCRIPTION
This simply add the support of the command `startWorldURL` with a check on the format on the neos record url.

As a bonus i added some logic for check if the neos record url format was started with `neosrec://`. While your parsing seems to not cause any problem, i was having issue on my hand with another project when i was putting, by mistake the neos world url. Having this small security is a good bonus I think. Tell what you think i could remove it if you not like it.