### PR TITLE
Add startWorldTemplate command support

### DIFF
--- a/commands.txt
+++ b/commands.txt
@@ -32,6 +32,9 @@ status
 friendRequests
 	Lists all incoming friend requests
 	Usage: friendrequests
+startWorldTemplate
+	Start a new world from template
+	Usage: startworldtemplate <template name>
 sessionUrl
 	Prints the URL of the current session
 	Usage: sessionurl 
@@ -126,9 +129,6 @@ acceptFriendRequest
 startWorldURL
 	Start a new world from URL
 	Usage: startworldurl <record URL>
-startWorldTemplate
-	Start a new world from template
-	Usage: startworldtemplate <template name>
 import
 	Import an asset into the focused world
 	Usage: import <file path or URL>

--- a/neosvr_headless_api/__init__.py
+++ b/neosvr_headless_api/__init__.py
@@ -447,14 +447,23 @@ class HeadlessClient:
         """
         raise NotImplementedError("Not yet implemented")
 
-    # TODO: Implement `startWorldTemplate` here
-    def start_world_template(self, *args, **kwargs):
+    def start_world_template(self, world_template: str):
         """
-        Not yet implemented
+        Start a wolrd based on a given world template name
 
-        Raises `NotImplementedError`
+        Return nothing on success
+
+        Raise `NeosError` if the world template name is invalid
+        Raise `UnhandledError` for any unknown errors
         """
-        raise NotImplementedError("Not yet implemented")
+        cmd = self.send_command('startWorldTemplate  "%s"' % (world_template))
+        errors = ['Invalid preset name']
+        for ln in cmd:
+            if ln == "World running...":
+                return
+            elif ln in errors:
+                raise NeosError(ln)
+        raise UnhandledError("\n".join(cmd))
 
     def status(self, world: Union[str, int] = None) -> dict:
         """

--- a/neosvr_headless_api/__init__.py
+++ b/neosvr_headless_api/__init__.py
@@ -456,6 +456,21 @@ class HeadlessClient:
         Raise `NeosError` if the world template name is invalid
         Raise `UnhandledError` for any unknown errors
         """
+        templates_name = [
+            "SpaceWorld",
+            "Basic Empty",
+            "GridSpace",
+            "Microworld",
+            "Testing Scaling",
+            "ScratchSpace",
+            "ScratchSpace (mobile)",
+        ]
+        if not world_template not in templates_name:
+            raise NeosError(
+                'Invalid preset name. Choose between: %s' % ', '.join(
+                    templates_name
+                )
+            )
         cmd = self.send_command('startWorldTemplate  "%s"' % (world_template))
         errors = ['Invalid preset name']
         for ln in cmd:

--- a/neosvr_headless_api/__init__.py
+++ b/neosvr_headless_api/__init__.py
@@ -480,21 +480,6 @@ class HeadlessClient:
         Raise `NeosError` if the world template name is invalid
         Raise `UnhandledError` for any unknown errors
         """
-        templates_name = [
-            "SpaceWorld",
-            "Basic Empty",
-            "GridSpace",
-            "Microworld",
-            "Testing Scaling",
-            "ScratchSpace",
-            "ScratchSpace (mobile)",
-        ]
-        if not world_template not in templates_name:
-            raise NeosError(
-                'Invalid preset name. Choose between: %s' % ', '.join(
-                    templates_name
-                )
-            )
         cmd = self.send_command('startWorldTemplate  "%s"' % (world_template))
         errors = ['Invalid preset name']
         for ln in cmd:


### PR DESCRIPTION
Add support for start a world template.

I also added a small check for validate the world template name and return a list of accepted value since the neos headless dont do that. Its good for documentation for the end user of the API I suppose but could add more maintenance task for us. While I'm not sure the maintenance will be big since its just adding a string in a list anyway.